### PR TITLE
下記scalikejdbcのプラグインが読み込めず、起動時の画面でエラーになるので、scalikejdbcのドキュメントを参考に、build.s...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,10 @@ libraryDependencies ++= Seq(
 
 // scalikeJDBC
 libraryDependencies ++= Seq(
-  "org.scalikejdbc" %% "scalikejdbc"             % "2.2.+",
-  "org.scalikejdbc" %% "scalikejdbc-play-plugin" % "2.3.+",
+  "org.scalikejdbc" %% "scalikejdbc"                       % "2.2.+",
+  "org.scalikejdbc" %% "scalikejdbc-config"                % "2.2.+",
+  "org.scalikejdbc" %% "scalikejdbc-play-plugin"           % "2.3.+",
+  "org.scalikejdbc" %% "scalikejdbc-play-fixture-plugin"   % "2.3.+", // optional
   "com.h2database"  %  "h2"                % "1.4.186",
   "ch.qos.logback"  %  "logback-classic"   % "1.1.2"
 )


### PR DESCRIPTION
...btにpluginを追加。（※参照：http://scalikejdbc.org/documentation/playframework-support.html）

・エラー内容「Plugin [scalikejdbc.PlayPlugin] cannot be instantiated.」
